### PR TITLE
remove erroneous slashes from appsettings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Microsot.AspNetCore.Authentication.OpenIdConnect
          "Default":"Warning"
       }
    },
-   "AllowedHosts":"\\*",
+   "AllowedHosts":"*",
    "Authentication":{
     "Cognito": {
       "ClientId": "\\<app client id from AWS Cognito\\>",


### PR DESCRIPTION
#2  BAD REQUEST - INVALID HOSTNAME

Erroneous slashes in the value for AllowedHosts have found there way into the suggested appsettings.json; trying to get the sample running, without realising the cause of the strange errors, can be troublesome.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
